### PR TITLE
Item control

### DIFF
--- a/src/common/game/environment/environments.js
+++ b/src/common/game/environment/environments.js
@@ -157,7 +157,7 @@ class SingleMapEnvironment extends Environment {
     info() {
         const info = {};
         info[TrainingInformationKey.ENV_KEYS.TYPE] = SingleMapEnvironment.ID;
-        info[TrainingInformationKey.ENV_KEYS.MAPS] = [this.#map.name];
+        info[TrainingInformationKey.ENV_KEYS.MAPS] = [ this.#map.name ];
         info[TrainingInformationKey.ENV_KEYS.POLICY] = this.policy.name;
         info[TrainingInformationKey.ENV_KEYS.STATE] = this.stateGenerator.info();
 
@@ -246,7 +246,7 @@ class ListMapEnvironment extends Environment {
     }
 
     createGame() {
-        return Survaillant.createGame(this.#maps[tf.randomUniform([1], 0, this.#maps.length, "int32").dataSync()[0]]);
+        return Survaillant.createGame(this.#maps[tf.randomUniform([ 1 ], 0, this.#maps.length, "int32").dataSync()[0]]);
     }
 
     id() {

--- a/src/common/game/environment/importer.js
+++ b/src/common/game/environment/importer.js
@@ -10,7 +10,7 @@ import { fromNetwork as loadPpoFinalNetwork } from "../../../ppo/networks.js";
 import { fromNetwork as loadDdpgFinalNetwork } from "../../../ddpg/networks.js";
 import { TrainingInformationKey } from "../training.js";
 import { createPolicy } from "./reward.js";
-import { FlashlightStateGenerator, Generator, NormalStateGenerator } from "./state/states.js";
+import { FlashlightStateGenerator, FlashlightItemsStateGenerator, Generator, NormalStateGenerator } from "./state/states.js";
 import { EntitiesRepresentation } from "./state/tensor.js";
 
 /**
@@ -55,6 +55,9 @@ async function loadFrom(modelFile, trainingInfoFile, fileLoader) {
         switch (mode) {
             case Generator.FLASHLIGHT:
                 return new FlashlightStateGenerator(parameters[TrainingInformationKey.ENV_KEYS.STATE_KEYS.PARAMETERS_KEYS.FLASHLIGHT.RADIUS], representation);
+
+            case Generator.FLASHLIGHTWITHITEMS:
+                return new FlashlightItemsStateGenerator(parameters[TrainingInformationKey.ENV_KEYS.STATE_KEYS.PARAMETERS_KEYS.FLASHLIGHT.RADIUS], representation);
 
             case Generator.NORMAL: {
                 const dimensions = parameters[TrainingInformationKey.ENV_KEYS.STATE_KEYS.PARAMETERS_KEYS.NORMAL.DIMENSIONS];

--- a/src/common/game/environment/reward.js
+++ b/src/common/game/environment/reward.js
@@ -11,12 +11,14 @@ const MOVED_INFO = { reward: 1, done: false };
 
 const BANDIT_POLICY = {};
 BANDIT_POLICY[Survaillant.ActionConsequence.GAME_OVER] = GAME_OVER_INFO;
+BANDIT_POLICY[Survaillant.ActionConsequence.ITEM_MISSING] = { reward: -1, done: false };
 BANDIT_POLICY[Survaillant.ActionConsequence.BAD_MOVEMENT] = { reward: -1, done: false };
 BANDIT_POLICY[Survaillant.ActionConsequence.MOVED] = MOVED_INFO;
 BANDIT_POLICY[Survaillant.ActionConsequence.KILL] = BANDIT_POLICY[Survaillant.ActionConsequence.MOVED];
 
 const NEUTRAL_POLICY = {};
 NEUTRAL_POLICY[Survaillant.ActionConsequence.GAME_OVER] = GAME_OVER_INFO;
+NEUTRAL_POLICY[Survaillant.ActionConsequence.ITEM_MISSING] = NEUTRAL_POLICY[Survaillant.ActionConsequence.GAME_OVER];
 NEUTRAL_POLICY[Survaillant.ActionConsequence.BAD_MOVEMENT] = NEUTRAL_POLICY[Survaillant.ActionConsequence.GAME_OVER];
 NEUTRAL_POLICY[Survaillant.ActionConsequence.MOVED] = MOVED_INFO;
 NEUTRAL_POLICY[Survaillant.ActionConsequence.KILL] = NEUTRAL_POLICY[Survaillant.ActionConsequence.MOVED];
@@ -103,8 +105,15 @@ RewardPolicies.SCORE_BASED = class ScoreDrivenPolicy {
      */
     get(consequence, game) {
         // Compute reward
-        const res = consequence === Survaillant.ActionConsequence.GAME_OVER || consequence === Survaillant.ActionConsequence.BAD_MOVEMENT ?
-            RewardPolicies.NEUTRAL.get(consequence) : { reward: Math.abs(game.stats.score - this.#score), done: false };
+        const gameEndingConsequences = [
+            Survaillant.ActionConsequence.GAME_OVER,
+            Survaillant.ActionConsequence.BAD_MOVEMENT,
+            Survaillant.ActionConsequence.ITEM_MISSING
+        ];
+
+        const res = gameEndingConsequences.includes(consequence) ?
+            RewardPolicies.NEUTRAL.get(consequence) :
+            { reward: Math.abs(game.stats.score - this.#score), done: false };
 
         // Update last score
         this.#score = game.stats.score;

--- a/src/common/game/environment/state/states.js
+++ b/src/common/game/environment/state/states.js
@@ -276,7 +276,7 @@ class FlashlightItemsStateGenerator extends FlashlightStateGenerator {
     }
 
     shape() {
-        return { x: this.#stateDim, y: this.#stateDim, z: this.tensorInfo.layers + 1 }; // Added one layer for the items
+        return { x: this.#stateDim, y: this.#stateDim, z: this.tensorInfo.layers + 1 }; // Added one layer for the item number
     }
 
     state(game) {
@@ -286,7 +286,7 @@ class FlashlightItemsStateGenerator extends FlashlightStateGenerator {
         const playerPosition = gameState.players[0].pos;
 
         const stateDim = this.#stateDim;
-        const state = tf.buffer([stateDim, stateDim, this.tensorInfo.layers + 1]); // Added one layer for the items
+        const state = tf.buffer([ stateDim, stateDim, this.tensorInfo.layers + 1 ]); // Added one layer for the item number
 
         // Define state bounds
         const minX = playerPosition.x - this.#radius;

--- a/src/common/game/environment/state/states.js
+++ b/src/common/game/environment/state/states.js
@@ -350,7 +350,7 @@ class FlashlightItemsStateGenerator extends FlashlightStateGenerator {
 
 const Generator = {
     FLASHLIGHT: "FLASHLIGHT",
-    FLASHLIGHT_ITEMS: "FLASHLIGHT_ITEMS",
+    FLASHLIGHTWITHITEMS: "FLASHLIGHTWITHITEMS",
     NORMAL: "NORMAL"
 };
 

--- a/src/common/game/stats.js
+++ b/src/common/game/stats.js
@@ -227,7 +227,8 @@ class GameStats {
     }
 
     /**
-     * Get the game over reason (either {@link Survaillant#ActionConsequence#BAD_MOVEMENT} or {@link Survaillant#ActionConsequence#GAME_OVER})
+     * Get the game over reason(either {@link Survaillant#ActionConsequence#BAD_MOVEMENT},
+     *  {@link Survaillant#ActionConsequence#GAME_OVER} or {@link Survaillant#ActionConsequence#ITEM_MISSING})
      *
      * @return {String} Reason
      */
@@ -238,13 +239,15 @@ class GameStats {
     /**
      * Set the game over reason
      *
-     * @param value New reason (either {@link Survaillant#ActionConsequence#BAD_MOVEMENT} or {@link Survaillant#ActionConsequence#GAME_OVER})
+     * @param value New reason (either {@link Survaillant#ActionConsequence#BAD_MOVEMENT},
+     *  {@link Survaillant#ActionConsequence#GAME_OVER} or {@link Survaillant#ActionConsequence#ITEM_MISSING})
      */
     set gameOverReason(value) {
-        if (value !== Survaillant.ActionConsequence.BAD_MOVEMENT && value !== Survaillant.ActionConsequence.GAME_OVER) {
+        if (value !== Survaillant.ActionConsequence.BAD_MOVEMENT &&
+         value !== Survaillant.ActionConsequence.GAME_OVER &&
+         value !== Survaillant.ActionConsequence.ITEM_MISSING) {
             throw new Error(`Unknown game over reason: ${value}`);
         }
-
         this.#reason = value;
     }
 

--- a/src/survaillant/src/index.js
+++ b/src/survaillant/src/index.js
@@ -28,12 +28,12 @@ const Survaillant = {
     createGame: (map) => {
         return new SurvaillantGame(map, "solo");
     },
-    PlayerMoves: [[-1, 0], [1, 0], [0, -1], [0, 1]],
+    PlayerMoves: [ [ -1, 0 ], [ 1, 0 ], [ 0, -1 ], [ 0, 1 ] ],
     PlayerMovesWithItems: [
-        ["movement", -1, 0], ["movement", 1, 0], ["movement", 0, -1], ["movement", 0, 1],
-        ["arrow", -1, 0], ["arrow", 1, 0], ["arrow", 0, -1], ["arrow", 0, 1],
-        ["bomb", -1, 0], ["bomb", 1, 0], ["bomb", 0, -1], ["bomb", 0, 1],
-        ["dynamite", -1, 0], ["dynamite", 1, 0], ["dynamite", 0, -1], ["dynamite", 0, 1]
+        [ "movement", -1, 0 ], [ "movement", 1, 0 ], [ "movement", 0, -1 ], [ "movement", 0, 1 ],
+        [ "arrow", -1, 0 ], [ "arrow", 1, 0 ], [ "arrow", 0, -1 ], [ "arrow", 0, 1 ],
+        [ "bomb", -1, 0 ], [ "bomb", 1, 0 ], [ "bomb", 0, -1 ], [ "bomb", 0, 1 ],
+        [ "dynamite", -1, 0 ], [ "dynamite", 1, 0 ], [ "dynamite", 0, -1 ], [ "dynamite", 0, 1 ]
     ],
     ActionConsequence: {
         MOVED: "MOVED",
@@ -111,7 +111,7 @@ class SurvaillantGame {
 
     // TODO: Doc
     useItem(item, dx, dy) {
-        const availableItems = ["arrow", "bomb", "dynamite"];
+        const availableItems = [ "arrow", "bomb", "dynamite" ];
         let player = this.game.players[0];
 
         if (item == undefined || !availableItems.includes(item))

--- a/src/survaillant/src/index.js
+++ b/src/survaillant/src/index.js
@@ -118,7 +118,7 @@ class SurvaillantGame {
             throw "A correct Item is required";
 
         if (player.inventory[item] <= 0) // The player doesn't have the item
-            return Survaillant.ActionConsequence.ITEM_MISSING;
+            return this.#stats.gameOverReason = Survaillant.ActionConsequence.ITEM_MISSING;
 
         // set item to the player
         player.selectedItem = item;

--- a/src/survaillant/src/index.js
+++ b/src/survaillant/src/index.js
@@ -28,10 +28,17 @@ const Survaillant = {
     createGame: (map) => {
         return new SurvaillantGame(map, "solo");
     },
-    PlayerMoves: [ [ -1, 0 ], [ 1, 0 ], [ 0, -1 ], [ 0, 1 ] ],
+    PlayerMoves: [[-1, 0], [1, 0], [0, -1], [0, 1]],
+    PlayerMovesWithItems: [
+        ["movement", -1, 0], ["movement", 1, 0], ["movement", 0, -1], ["movement", 0, 1],
+        ["arrow", -1, 0], ["arrow", 1, 0], ["arrow", 0, -1], ["arrow", 0, 1],
+        ["bomb", -1, 0], ["bomb", 1, 0], ["bomb", 0, -1], ["bomb", 0, 1],
+        ["dynamite", -1, 0], ["dynamite", 1, 0], ["dynamite", 0, -1], ["dynamite", 0, 1]
+    ],
     ActionConsequence: {
         MOVED: "MOVED",
         BAD_MOVEMENT: "BAD_MOVEMENT",
+        ITEM_MISSING: "ITEM_MISSING",
         GAME_OVER: "GAME_OVER",
         KILL: "KILL"
     }
@@ -103,20 +110,22 @@ class SurvaillantGame {
     }
 
     // TODO: Doc
-    selectItem(item) {
-        const availableItems = [ "", "arrow", "bomb", "dynamite" ];
-
-        let player = this.game.player[0];
+    useItem(item, dx, dy) {
+        const availableItems = ["", "arrow", "bomb", "dynamite"];
+        let player = this.game.players[0];
 
         if (item == undefined || !availableItems.includes(item))
             throw "A correct Item is required";
 
-        if (player.inventory[item] == 0) // The player has no item
-            return -1;
+        if (player.inventory[item] <= 0) // The player doesn't have the item
+            return Survaillant.ActionConsequence.ITEM_MISSING;
 
         // set item to the player
         player.selectedItem = item;
         player.nextMove = null;
+
+        // Execute the movement
+        return this.movePlayer(dx, dy);
     }
 }
 

--- a/src/survaillant/src/index.js
+++ b/src/survaillant/src/index.js
@@ -111,7 +111,7 @@ class SurvaillantGame {
 
     // TODO: Doc
     useItem(item, dx, dy) {
-        const availableItems = ["", "arrow", "bomb", "dynamite"];
+        const availableItems = ["arrow", "bomb", "dynamite"];
         let player = this.game.players[0];
 
         if (item == undefined || !availableItems.includes(item))

--- a/src/validator/validate.js
+++ b/src/validator/validate.js
@@ -108,7 +108,6 @@ async function main() {
     // Run maps
     const stats = new GamesStats();
     for (const map of maps) {
-        console.log("map");
         const env = trainingInfo.env.items?.type === "fullList" ?
             new SingleMapEnvironmentWithItems(map, policy, stateGenerator) :
             new SingleMapEnvironment(map, policy, stateGenerator);

--- a/src/validator/validate.js
+++ b/src/validator/validate.js
@@ -9,7 +9,7 @@ import fs from "fs";
 import { join, sep } from "path";
 import ProgressBar from "progress";
 import { array, path } from "../common/argparse.js";
-import { SingleMapEnvironment } from "../common/game/environment/environments.js";
+import { SingleMapEnvironment, SingleMapEnvironmentWithItems } from "../common/game/environment/environments.js";
 import loadFrom from "../common/game/environment/importer.js";
 import { GamesStats } from "../common/game/stats.js";
 import { TrainingInformationKey } from "../common/game/training.js";
@@ -108,7 +108,11 @@ async function main() {
     // Run maps
     const stats = new GamesStats();
     for (const map of maps) {
-        const env = new SingleMapEnvironment(map, policy, stateGenerator);
+        console.log("map");
+        const env = trainingInfo.env.items?.type === "fullList" ?
+            new SingleMapEnvironmentWithItems(map, policy, stateGenerator) :
+            new SingleMapEnvironment(map, policy, stateGenerator);
+
         const progress = new ProgressBar(`Playing '${map.name}' [:bar] :rate/gps :percent :etas`, { total: games, complete: "=", incomplete: " ", width: 20 });
 
         // Pay games


### PR DESCRIPTION
Ajout d'un type d'env flashlight dans lequel l'inventaire (le nb d'item) est ajouté dans une nouvelle couche pour le modèle
A ajouter dans le modèle training info .json dans env : 
`        
"state": {
        "type": "flashlightWithItems",
       ...
`

Ajout d'un type d'entrée ou l'on attend du modèle 16 actions : 4 déplacements et 4 x 3 pour chaque item
A ajouter dans le modèle training info .json dans env : 
`        
"items": {
            "type": "fullList"
}
`

Pas testé le training, mail l'eval marche, ajout de la gameover reason "ITEM_MISSING" pour quand l'ia veut utiliser un item qu'elle n'a pas